### PR TITLE
🛡️ Sentinel: [Medium] Fix unhandled exceptions on implicit intent launches

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,1 @@
+- 2024-05-18: [Medium - Unhandled intents] Always wrap external implicit intents like startActivity or showInputMethodPicker in try/catch to prevent crashes.

--- a/app/src/main/java/br/tec/lew/vibeboard/MainActivity.kt
+++ b/app/src/main/java/br/tec/lew/vibeboard/MainActivity.kt
@@ -1,6 +1,7 @@
 package br.tec.lew.vibeboard
 
 import android.Manifest
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
@@ -81,15 +82,25 @@ fun SetupScreen(modifier: Modifier = Modifier) {
         }
 
         Button(onClick = {
-            context.startActivity(Intent(Settings.ACTION_INPUT_METHOD_SETTINGS))
+            try {
+                context.startActivity(Intent(Settings.ACTION_INPUT_METHOD_SETTINGS))
+            } catch (e: ActivityNotFoundException) {
+                reportError(e, mapOf("action" to "startActivity", "intent" to Settings.ACTION_INPUT_METHOD_SETTINGS))
+            } catch (e: Exception) {
+                reportError(e, mapOf("action" to "startActivity", "intent" to Settings.ACTION_INPUT_METHOD_SETTINGS))
+            }
         }) {
             Text("1. Enable Vibeboard in Settings")
         }
         Spacer(modifier = Modifier.height(16.dp))
 
         Button(onClick = {
-            val imm = context.getSystemService(InputMethodManager::class.java)
-            imm?.showInputMethodPicker()
+            try {
+                val imm = context.getSystemService(InputMethodManager::class.java)
+                imm?.showInputMethodPicker()
+            } catch (e: Exception) {
+                reportError(e, mapOf("action" to "showInputMethodPicker"))
+            }
         }) {
             Text("2. Select Vibeboard as Input Method")
         }


### PR DESCRIPTION
🛡️ Sentinel: [Medium] Fix unhandled exceptions on implicit intent launches

**Vulnerability**: Unhandled exceptions triggered by implicit external intents (`startActivity` for `ACTION_INPUT_METHOD_SETTINGS` and `showInputMethodPicker()`).
**Impact**: On certain custom Android ROMs or restricted profiles, these standard settings actions might be unavailable, leading to an unhandled `ActivityNotFoundException` or generic `Exception`, crashing the app without centralized error reporting.
**Fix**: Wrapped these calls in `MainActivity.kt` with a `try/catch` block that forwards the exceptions to the centralized `reportError` function, adhering to the "no silent failures" rule.
**Verification**: Ensured that the `.jules/sentinel.md` was appropriately updated, tests run, and no forbidden files (`install-mise.sh`) were committed.

### Assumptions
- The `reportError` function properly captures exceptions context and forwards it correctly.
- Both `startActivity` and `showInputMethodPicker` can throw `ActivityNotFoundException` or related Android exceptions if the target action isn't resolved by the package manager.

### Alternatives Not Chosen
- Verifying the intent resolution using `PackageManager.resolveActivity` before launching. Chosen alternative (try-catch) is simpler and directly satisfies the "route through `reportError`" rule.

### How To Pivot
- If you'd rather verify the intent beforehand, we can replace the try/catch with `if (intent.resolveActivity(packageManager) != null)` and show a Toast instead.

### Next Knobs
- `MainActivity.kt`: Change the fallback mechanism (e.g., displaying a Toast or AlertDialog) when the exception is caught, instead of just reporting it to Sentry/logs.
- `.jules/sentinel.md`: Update or refine the journal logging strategy if a different format is needed.

---
*PR created automatically by Jules for task [14504645841522210376](https://jules.google.com/task/14504645841522210376) started by @lucasew*