### PR TITLE
🛠️ Refactor: Extract InputController and ComposeLifecycleOwner from VibeboardService

### DIFF
--- a/app/src/main/java/br/tec/lew/vibeboard/ComposeLifecycleOwner.kt
+++ b/app/src/main/java/br/tec/lew/vibeboard/ComposeLifecycleOwner.kt
@@ -1,0 +1,51 @@
+package br.tec.lew.vibeboard
+
+import android.os.Bundle
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.savedstate.SavedStateRegistry
+import androidx.savedstate.SavedStateRegistryController
+import androidx.savedstate.SavedStateRegistryOwner
+
+/**
+ * Encapsulates the boilerplate required to provide a ViewTree Lifecycle,
+ * ViewModelStore, and SavedStateRegistry to Jetpack Compose from within
+ * a custom component like an InputMethodService.
+ *
+ * Rationale: Single Responsibility Principle (Martin). Separating the
+ * ViewTree lifecycle infrastructure into a dedicated class improves cohesion
+ * and reduces the service's cognitive load.
+ */
+class ComposeLifecycleOwner : LifecycleOwner, ViewModelStoreOwner, SavedStateRegistryOwner {
+
+    private val lifecycleRegistry = LifecycleRegistry(this)
+    override val lifecycle: Lifecycle get() = lifecycleRegistry
+
+    private val store = ViewModelStore()
+    override val viewModelStore: ViewModelStore get() = store
+
+    private val savedStateRegistryController = SavedStateRegistryController.create(this)
+    override val savedStateRegistry: SavedStateRegistry get() = savedStateRegistryController.savedStateRegistry
+
+    fun onCreate() {
+        savedStateRegistryController.performRestore(null)
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+    }
+
+    fun onResume() {
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START)
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+    }
+
+    fun onPause() {
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+    }
+
+    fun onDestroy() {
+        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+    }
+}

--- a/app/src/main/java/br/tec/lew/vibeboard/InputController.kt
+++ b/app/src/main/java/br/tec/lew/vibeboard/InputController.kt
@@ -1,0 +1,46 @@
+package br.tec.lew.vibeboard
+
+import android.view.KeyEvent
+import android.view.inputmethod.InputConnection
+
+/**
+ * Handles interactions with the InputConnection.
+ *
+ * Rationale: Single Responsibility Principle (Martin) & Command Pattern (GoF).
+ * Delegating text manipulation and key event interactions (delete text, commit text,
+ * send key events) to a specific handler clarifies the InputMethodService's role
+ * as a mediator and encapsulates keyboard output logic.
+ */
+class InputController(private val inputConnectionProvider: () -> InputConnection?) {
+
+    private val currentInputConnection: InputConnection?
+        get() = inputConnectionProvider()
+
+    fun commitText(text: String, newCursorPosition: Int) {
+        currentInputConnection?.commitText(text, newCursorPosition)
+    }
+
+    fun setComposingText(text: String, newCursorPosition: Int) {
+        currentInputConnection?.setComposingText(text, newCursorPosition)
+    }
+
+    fun finishComposingText() {
+        currentInputConnection?.finishComposingText()
+    }
+
+    fun deleteSurroundingText(beforeLength: Int, afterLength: Int) {
+        currentInputConnection?.deleteSurroundingText(beforeLength, afterLength)
+    }
+
+    fun sendEnterEvent() {
+        finishComposingText()
+        currentInputConnection?.sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER))
+        currentInputConnection?.sendKeyEvent(KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_ENTER))
+    }
+
+    fun moveCursor(direction: Int) {
+        val keyEvent = if (direction > 0) KeyEvent.KEYCODE_DPAD_RIGHT else KeyEvent.KEYCODE_DPAD_LEFT
+        currentInputConnection?.sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, keyEvent))
+        currentInputConnection?.sendKeyEvent(KeyEvent(KeyEvent.ACTION_UP, keyEvent))
+    }
+}

--- a/app/src/main/java/br/tec/lew/vibeboard/VibeboardService.kt
+++ b/app/src/main/java/br/tec/lew/vibeboard/VibeboardService.kt
@@ -52,43 +52,28 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleOwner
 import br.tec.lew.vibeboard.ui.VibeboardKeyboard
-import androidx.lifecycle.LifecycleRegistry
-import androidx.lifecycle.ViewModelStore
-import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.lifecycle.setViewTreeViewModelStoreOwner
-import androidx.savedstate.SavedStateRegistry
-import androidx.savedstate.SavedStateRegistryController
-import androidx.savedstate.SavedStateRegistryOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import br.tec.lew.vibeboard.ui.theme.VibeboardTheme
 import kotlinx.coroutines.delay
 import java.util.Locale
 import kotlin.math.roundToInt
 
-class VibeboardService : InputMethodService(), LifecycleOwner, ViewModelStoreOwner, SavedStateRegistryOwner {
+class VibeboardService : InputMethodService() {
 
     private var speechRecognizer: SpeechRecognizer? = null
     private var isListening by mutableStateOf(false)
     private var onDeviceRecognitionAvailable by mutableStateOf(false)
     private val touchableRegion = Region()
 
-    private val lifecycleRegistry = LifecycleRegistry(this)
-    override val lifecycle: Lifecycle get() = lifecycleRegistry
-
-    private val store = ViewModelStore()
-    override val viewModelStore: ViewModelStore get() = store
-
-    private val savedStateRegistryController = SavedStateRegistryController.create(this)
-    override val savedStateRegistry: SavedStateRegistry get() = savedStateRegistryController.savedStateRegistry
+    private val composeLifecycleOwner = ComposeLifecycleOwner()
+    private val inputController = InputController { currentInputConnection }
 
     override fun onCreate() {
         super.onCreate()
-        savedStateRegistryController.performRestore(null)
-        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+        composeLifecycleOwner.onCreate()
         setupSpeechRecognizer()
     }
 
@@ -109,17 +94,17 @@ class VibeboardService : InputMethodService(), LifecycleOwner, ViewModelStoreOwn
             override fun onError(error: Int) { 
                 reportError(Exception("SpeechRecognizer error: $error"), mapOf("errorCode" to error))
                 isListening = false
-                currentInputConnection?.finishComposingText()
+                inputController.finishComposingText()
             }
             override fun onResults(results: Bundle?) {
                 results?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)?.firstOrNull()?.let {
-                    currentInputConnection?.commitText("$it ", 1)
+                    inputController.commitText("$it ", 1)
                 }
                 isListening = false
             }
             override fun onPartialResults(partialResults: Bundle?) {
                 partialResults?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)?.firstOrNull()?.let {
-                    currentInputConnection?.setComposingText(it, 1)
+                    inputController.setComposingText(it, 1)
                 }
             }
             override fun onEvent(eventType: Int, params: Bundle?) {}
@@ -142,9 +127,9 @@ class VibeboardService : InputMethodService(), LifecycleOwner, ViewModelStoreOwn
     override fun onCreateInputView(): View {
         return ComposeView(this).apply {
             window?.window?.decorView?.let { decor ->
-                decor.setViewTreeLifecycleOwner(this@VibeboardService)
-                decor.setViewTreeViewModelStoreOwner(this@VibeboardService)
-                decor.setViewTreeSavedStateRegistryOwner(this@VibeboardService)
+                decor.setViewTreeLifecycleOwner(composeLifecycleOwner)
+                decor.setViewTreeViewModelStoreOwner(composeLifecycleOwner)
+                decor.setViewTreeSavedStateRegistryOwner(composeLifecycleOwner)
             }
 
             setContent {
@@ -152,19 +137,15 @@ class VibeboardService : InputMethodService(), LifecycleOwner, ViewModelStoreOwn
                     VibeboardKeyboard(
                         isListening = isListening,
                         onBackspaceRepeat = {
-                            currentInputConnection?.deleteSurroundingText(1, 0)
+                            inputController.deleteSurroundingText(1, 0)
                         },
                         onBackspaceTap = {
-                            currentInputConnection?.finishComposingText()
-                            currentInputConnection?.deleteSurroundingText(1, 0)
+                            inputController.finishComposingText()
+                            inputController.deleteSurroundingText(1, 0)
                         },
                         onToggleListening = { toggleListening() },
-                        onEnterClick = {
-                            currentInputConnection?.finishComposingText()
-                            currentInputConnection?.sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER))
-                            currentInputConnection?.sendKeyEvent(KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_ENTER))
-                        },
-                        onMoveCursor = { moveCursor(it) },
+                        onEnterClick = { inputController.sendEnterEvent() },
+                        onMoveCursor = { inputController.moveCursor(it) },
                         onSwitchKeyboard = {
                             val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
                             val token = window.window?.attributes?.token
@@ -188,12 +169,6 @@ class VibeboardService : InputMethodService(), LifecycleOwner, ViewModelStoreOwn
                 }
             }
         }
-    }
-
-    private fun moveCursor(direction: Int) {
-        val keyEvent = if (direction > 0) KeyEvent.KEYCODE_DPAD_RIGHT else KeyEvent.KEYCODE_DPAD_LEFT
-        currentInputConnection?.sendKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, keyEvent))
-        currentInputConnection?.sendKeyEvent(KeyEvent(KeyEvent.ACTION_UP, keyEvent))
     }
 
     private fun toggleListening() {
@@ -221,19 +196,17 @@ class VibeboardService : InputMethodService(), LifecycleOwner, ViewModelStoreOwn
             win.navigationBarColor = android.graphics.Color.TRANSPARENT
             win.setDecorFitsSystemWindows(false)
         }
-        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START)
-        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+        composeLifecycleOwner.onResume()
     }
 
     override fun onWindowHidden() {
         super.onWindowHidden()
-        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
-        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+        composeLifecycleOwner.onPause()
     }
 
     override fun onDestroy() {
         super.onDestroy()
-        lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+        composeLifecycleOwner.onDestroy()
         speechRecognizer?.destroy()
     }
 }


### PR DESCRIPTION
Extracts the Jetpack Compose ViewTree lifecycle logic and the `InputConnection` logic from `VibeboardService` into two dedicated classes: `ComposeLifecycleOwner` and `InputController`. This adheres to the Single Responsibility Principle (Martin) and the Command Pattern (GoF), significantly reducing the complexity of the main service class.

### Assumptions
- The current implementation of `VibeboardService` handles too many responsibilities, violating the Single Responsibility Principle (Martin).
- Extracting the Compose ViewTree lifecycle components and InputConnection interaction logic into separate classes will improve cohesion, readability, and testability.

### Alternatives Not Chosen
- **Restructuring directory paths by domain:** Decided against this for now to focus strictly on class extractions, as moving many files simultaneously might create larger diffs and cause conflicts with other open PRs.
- **Extracting SpeechRecognizer logic:** Noticed there was already an open PR (#18) extracting speech recognition logic, so I avoided duplicating that effort to prevent merge conflicts.

### How To Pivot
- If the extracted classes `ComposeLifecycleOwner` and `InputController` are deemed over-engineered, the `VibeboardService` can be easily reverted to handle these responsibilities directly by inline expanding the extracted logic.

### Next Knobs
- Move domain-specific files (e.g., `ErrorHandler.kt` to `core`, `MainActivity.kt` to `setup`) to further enforce the directory structure grouped by domain.
- Create tests for the isolated `InputController` class since its dependencies are now easier to mock.

---
*PR created automatically by Jules for task [16680316380935199017](https://jules.google.com/task/16680316380935199017) started by @lucasew*