### PR TITLE
🧹 Janitor: Fix deprecation warnings in VibeboardService

### DIFF
--- a/.jules/janitor.md
+++ b/.jules/janitor.md
@@ -1,0 +1,1 @@
+- 2026-03-16: Suppressed deprecated Android API calls in InputMethodService.

--- a/app/src/main/java/br/tec/lew/vibeboard/VibeboardService.kt
+++ b/app/src/main/java/br/tec/lew/vibeboard/VibeboardService.kt
@@ -168,6 +168,7 @@ class VibeboardService : InputMethodService(), LifecycleOwner, ViewModelStoreOwn
                         onSwitchKeyboard = {
                             val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
                             val token = window.window?.attributes?.token
+                            @Suppress("DEPRECATION")
                             if (!imm.switchToLastInputMethod(token)) {
                                 imm.showInputMethodPicker()
                             }
@@ -213,6 +214,7 @@ class VibeboardService : InputMethodService(), LifecycleOwner, ViewModelStoreOwn
         }
     }
 
+    @Suppress("DEPRECATION")
     override fun onWindowShown() {
         super.onWindowShown()
         window?.window?.let { win ->


### PR DESCRIPTION
Adds `@Suppress("DEPRECATION")` to deprecated `InputMethodManager` and `Window` APIs in `VibeboardService` to ensure the build completes without warnings during lint checks. A single-sentence journal entry was also added to `.jules/janitor.md` as per guidelines.

### Assumptions:
- We want to suppress these API warnings rather than routing through newer APIs in order to maintain completely backward-compatible behavior without risking regressions in keyboard management or window styling.

### Alternatives Not Chosen:
- **Upgrading window management to `WindowCompat`:** Passed over to avoid potentially changing behavioral nuances of how the service window is displayed.
- **Upgrading `switchToLastInputMethod` to `switchToPreviousInputMethod`:** Skipped because the former specifically targets the `InputMethodManager` rather than the service directly, and suppressing maintains exactly identical logic.

### How To Pivot:
- If newer APIs are preferred, remove the `@Suppress("DEPRECATION")` tags and implement the `WindowCompat` alternatives and API 31+ `InputMethodService` methods.

### Next Knobs:
- The `@Suppress` annotations in `VibeboardService.kt`.
- The lint configuration to globally suppress these if the warnings return or if we want to avoid suppressing per-file.

---
*PR created automatically by Jules for task [9337372159520822486](https://jules.google.com/task/9337372159520822486) started by @lucasew*